### PR TITLE
Added #red after .svg file, to visualise Equinor logo in red color

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -7,7 +7,7 @@
 $mossgreen: #007079;
 
 .site-title::before {
-	content: url( https://eds-static.equinor.com/logo/equinor-logo-primary.svg);
+	content: url( https://eds-static.equinor.com/logo/equinor-logo-primary.svg#red);
 	display: inline-block;
 	position: relative;
 	width: 3rem;


### PR DESCRIPTION
Change .scss file to reflect the red color in the logo. #red after the .svg file/url.