### PR TITLE
Header file for use to give favico

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='{{ '/assets/main.css' | relative_url }}'>
+<link rel='icon' type='image/x-icon' href='{{ 'favicon.ico' | relative_url }}'>


### PR DESCRIPTION
Without a _includes/header.html file, the favico.ico is expected to be in `equinor.github.io`which is not. It does not include the `appsec`directory. 