### PR TITLE
fix broken link to snyk guidelines

### DIFF
--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -7,6 +7,6 @@ title: Appsec guidelines
 
 This section contains guidelines relevant anyone writing code in Equinor.
 
-- [Snyk](/snyk)
+- [Snyk](../snyk)
 - [Scanning for Secrets in code](secret-scanning)
 - [Postman](postman)


### PR DESCRIPTION
The link currently leads to `https://equinor.github.io/snyk` which does not exist