### PR TITLE
Fix dead links and update extension

### DIFF
--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -7,6 +7,6 @@ title: Appsec guidelines
 
 This section contains guidelines relevant anyone writing code in Equinor.
 
-- [Snyk](../snyk/)
-- [Scanning for Secrets in code](secret-scanning)
-- [Postman](postman)
+- [Snyk](../snyk/index.md)
+- [Scanning for Secrets in code](secret-scanning.md)
+- [Postman](postman.md)

--- a/docs/guidelines/secret-scanning.md
+++ b/docs/guidelines/secret-scanning.md
@@ -20,7 +20,7 @@ Please note that:
 - Incremental scans would be helpful, you may not want to scan everything all the time
 - Don't underestimate the cultural change when changing how you work. Good practices are to document how your team does Secure Development and to threat model how you work. Use/revisit this information regularly in on-boarding of new team members and in retrospectives.
 
-(Check out the [appsec tools section](/appsec/resources/tools) for more tooling)
+(Check out the [appsec tools section](../resources/tools.md) for more tooling)
 
 ## Where to scan for secrets in our SDLC
 
@@ -30,7 +30,7 @@ While your are developing, in your development environment
 
 - Scan in your IDE (using Snyk Code)
 - Scan in your local build process (using Trufflehog)
-- Scan in git [pre-commits](../faq/pre-commit-faq.md) (Run a trufflehog scan on commit for example?)
+- Scan in git [pre-commits](FAQ/pre-commit-faq.md) (Run a trufflehog scan on commit for example?)
 
 In your CI pipeline
 

--- a/docs/resources/tools.md
+++ b/docs/resources/tools.md
@@ -24,7 +24,7 @@ These built in tools are quite extensive, and you can get very far in inspecting
 [Burp Suite](https://portswigger.net/burp/communitydownload) is a graphical platform for performing security testing of web applications. Its various tools work seamlessly together to support the entire testing process, from initial mapping and analysis of an application's attack surface, through to finding and exploiting security vulnerabilities.
 
 ### Pre-commit framework
-[Pre-commit](https://pre-commit.com/) is a framework for managing and maintaining multi-language pre-commit hooks. Check out our [FAQ](../faq/pre-commit-faq.md) to get started using pre-commit!
+[Pre-commit](https://pre-commit.com/) is a framework for managing and maintaining multi-language pre-commit hooks. Check out our [FAQ](../guidelines/FAQ/pre-commit-faq.md) to get started using pre-commit!
 
 ## Expert
 ### Kali Linux

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,8 +45,8 @@ extra_css:
 markdown_extensions:
   - attr_list
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.details
   - admonition
   - toc:


### PR DESCRIPTION
Fixed dead links and cleaned up warnings in terminal by updating twemoji extension and cleaning up relative links.
The materialx library was deprecated and moved to material.extensions.emoji.