### PR TITLE
Add git guidelines on authentication and signing

### DIFF
--- a/docs/guidelines/git-github.md
+++ b/docs/guidelines/git-github.md
@@ -1,0 +1,307 @@
+# Git and Github
+
+This guideline contains some basic information on configuration of git and user profiles on github.com. Our perspective would be security and privacy. The guideline is by no means exhaustive, it's more an introduction to basic config and the correlation between git and github.com
+
+!!! tip "Git vs Github.com"
+    Git is a distributed version control system for tracking changes in source code, while GitHub is a platform that hosts Git repositories online, facilitating collaboration and project management. GitHub builds upon Git, offering a centralized place for developers to share and work on code together.
+
+[The Equinor Developer Portal](https://developer.equinor.com/) contain our [Source Code Management System Policy](https://developer.equinor.com/governance/scm-policy/). Please make sure you are familiar with the content of this policy.
+
+## TLDR;
+
+- Configure your local git with proper name and email. Use your full name with the profile. Use privacy options for hiding your github.com primary email.
+- For authentication and communication with github.com, use git with SSH and password protected private keys.
+- Use separate SSH keys for different client devices.
+- Book a yearly re-occurring event with yourself to rotate SSH keys and passphrases.
+
+## Git
+
+For this guideline our reference is using git from the command line. There are many tools in use which utilises git and hide the internal mechanics of git configuration within the tool.
+
+We assume that git and ssh is installed on your system. We do not cover the installation process besides mentioning the fact now that git and ssh like any other piece of software, should be kept up-to-date.
+
+The official [git documentation](https://git-scm.com/doc) is a good source for authoriative answers and deep dives.
+
+
+### How git manages config
+
+Git is dependent on proper configuration to work. Configuration can be read from the command line (using the `-c` option), environment variables or files. The [official guide]([authoriative](https://git-scm.com/docs/git-config#_configuration)) provides the details. 
+
+We usually store git config in files. Git will read config from multiple files depending on their availability. The files are read in the order shown below, the `last value read` will take precedence over values read earlier.
+
+1. System config (usually `/etc/gitconfig`)
+2. Config file in home directory (usually `$HOME/.gitconfig`)
+3. Repository config files (`$GITDIR/config`)
+  
+The config files can be updated manually or by using git
+
+```shell
+git config <section>.<key> <value>
+```
+
+Example; setting the user name:
+
+```shell
+git config user.name "Peter Pan"
+```
+
+Reading the config looks like this:
+
+```shell
+git config --get user.name
+Peter Pan
+```
+
+Removing config looks like this:
+
+```shell
+git config --unset user.name
+```
+
+For the examples above no "scope" is provided so git will work with repo config file. Use the parameter `--system`, `--global` or `--local` to specify scope.
+
+Setting your user name for a global scope would look like this:
+
+```shell
+git config --global user.name "Peter Pan"
+```
+
+
+### Recommended generic basic config
+
+!!! tip "Recommended generic config"
+
+    This section contains the recommended basic generic config for git.
+
+
+```shell
+git config --global user.name "value"
+git config --global user.email "value"
+```
+
+- The value for username should be your full name ([SCM Policy](https://developer.equinor.com/governance/scm-policy/))
+- The value for user email should be the "[Not visible in emails](https://github.com/settings/emails)" value from your github.com account. The format will usually be `ID+USERNAME@users.noreply.github.com` (Privacy, [Official Github documentation](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address))
+
+!!! tip "Additional email privacy"
+
+    We also recommend that you set the "Keep my email address private" and even "Block command line pushes that expose my email" in [email section](https://github.com/settings/emails) of your profile on github.com
+
+
+### Using SSH with git
+
+Git uses HTTP or SSH to communicate with github.com. Both alternatives are viable and provide a good level of security. HTTP(S) assumes the usage of PAT (Personal Access Token) tokens rather than account passwords. A short threat model of the options could like this:
+
+
+| Threat                | SSH (with password-protected keys)                       | HTTPS (with PATs)                                              |
+|-----------------------|---------------------------------------------------------|----------------------------------------------------------------|
+| **Interception**      | Encrypted; MITM attack needed. Passphrases protect keys on disk, but not in transit since keys aren't transmitted. | Encrypted; susceptible to MITM, but TLS and certificate validation mitigate risks. PATs are used instead of passwords.  |
+| **Impersonation**     | Theft of private key and passphrase required for impersonation. | Relies on secure storage of PATs. Impersonation possible if a PAT is exposed. |
+| **Eavesdropping**     | Encrypted traffic; passphrase adds security at rest, not in transit. | Encrypted traffic; PATs should be securely stored to prevent unauthorized access. |
+| **Authentication**    | Strong, with added layer of passphrase protection for key files. | PATs can be set to expire, enhancing security by limiting the lifespan of access credentials. |
+| **Configuration**     | Requires management of key pairs and passphrases, slightly more complex. | Requires management of PATs, including regular rotation and setting appropriate expiration dates. |
+| **Availability**      | Direct; less prone to web attacks, but firewalls might block SSH. | High through standard web ports; PATs can be revoked or expire, requiring renewal for continued access. |
+| **Key/Token Expiry**  | SSH keys do not expire by default; requires manual rotation for security. | PATs can be configured to expire, forcing regular renewal and review of access permissions. |
+| **Theft of Credentials** | Risk mitigated by passphrase encryption of the private key. Physical access or malware required to steal. | Risk of PAT exposure, especially if stored insecurely or transmitted over insecure channels. |
+| **Least privilege** | SSH keys can inherit all permissions of a user. No granularity | PAT tokens can be configured for fine grained permissions and then provide access to all or only specific repos. This could strengthen security. Token management will add extra complexity. |
+
+
+!!! tip "Use SSH with git"
+
+    We recommend using SSH with git authenticates and communicates with github.com. Private keys should be password protected (or stored in a strong key service/device, like Keychain on MacOS or Yubikey's)
+
+
+### Configuring git to use SSH
+
+The [Connecting to GitHub with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) in the official Github doc is a good source for information.
+
+These would be the usual steps:
+
+#### [Generate a new SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)
+  - Type of key should be `ed25519`
+  - Specify a filename (`-f`). We assume you can have multiple keys and suggest a naming convention like "service"-"identity"-"index". The index could be creation date and then used for automating key rotation.
+  - Add a comment (`-C`) to help identify the key's purpose. This will be added to the public key as generic text and have no functional impact. It will not be exposed on github.com. However, the purpose of a public key is to "share it", so use with caution (PII).
+
+Example; Creating a ssh key for the github handle `larskaare`
+
+```shell
+ssh-keygen -t ed25519 -f ~/.ssh/github_larskaare_1 -C "Github ssh for machine 1"
+```
+
+Two files are created, one named `github_larskaare_1` and one named `github_larskaare_1.pub`. The file with the `.pub` extension contains the public part of the key.
+
+!!! Tip "Re-using keys?"
+
+    We advice on creating separate ssh keys for separate machine and devices and not to re-use one key on them all.
+
+!!! Tip "Passphrases"
+
+    Store passphrases in a password manager.
+
+!!! Tip "Use a password manager to generate and serve SSK keys"
+
+    Using a decent password manager to generate, serve and protect the SSH keys could be a very good option. The private key will not be stored on disk and biometrics could be used to access keys.
+
+#### Configure SSH and adding the key to the key-agent
+
+Adding the generated SSH key to the `ssh-agent` gives you a secure repository for your private keys's passphrases. Adding keys and passphrases to the key agent eliminates the need to repeatedly enter the passphrase.
+
+Follow the [official documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent) of adding the SSH key to the ssh-agent. Be aware of the operating system selector at the top of the page - it will give you instructions for **Mac**, **Windows** and **Linux**.
+
+
+#### Adding SSH config
+
+SSH uses a config files for it's configuration (these are not the same files that git use). The user-specific file is usually stored in `~/.ssh/config` and should updated prior to using the SSH key and the ssh-key agent. Depending on you version of SSH, documentation is often available using the command `man ssh_config`. The [OpenSSH Manual Pages](https://www.openssh.com/manual.html) could also be a good resource.
+
+A typical set-up for MacOS for the key we generated in the example would look like this:
+
+```
+Host github.com
+    AddKeysToAgent yes
+    IdentitiesOnly=yes
+    UseKeychain yes
+    IdentityFile ~/.ssh/github_larskaare_1
+```
+
+#### Adding the private SSH key to the SSH agent
+
+We assume that the `ssh-agent` is available and running.
+
+The following command will add the private part of the SSH key we generated to the ssh-agent
+
+```shell
+ssh-add ~/.ssh/github_larskaare_1
+```
+
+For MacOS we would typically add the passphrase to the keychain as well
+
+```shell
+ssh-add --apple-use-keychain ~/.ssh/github_larskaare_1
+```
+
+### Configure github.com to use our SSH key
+
+We now have a SSH key that we can use when communicating with github.com. To be able to use this key with Github we need to upload the public part of the key to github.com
+
+- List public key
+```shell
+   cat ~/.ssh/github_larskaare_1.pub
+```
+
+- Copy the public key and add it as a new SSH Authentication key to your Github profile at [https://github.com/settings/keys](https://github.com/settings/keys)
+
+- Verify that Github accepts the key, test the connection
+
+```shell
+ssh -T git@github.com
+```
+
+The command should a message similar to this to indicate success:
+
+```
+Hi larskaare! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+### Using git with SSH with github
+
+A this stage we have SSH all configured on both ends, how do we tell git to use SSH? You typically would do this when cloning a repo or configuring the `remote`
+
+- A git clone command like this `git clone git@github.com:equinor/appsec.git` tells git to use SSH. The same command for using HTTPS would be git `git clone https://github.com/equinor/appsec.git`. The giveaway for SSH would be the username part `git@github.com` of the url.
+- You can examine the remote of a repo to identify if it uses SSH or HTTPS
+
+```shell
+git remote -v
+```
+
+should out output remote name and a URI containing the `git@github.com`
+
+```
+origin	git@github.com:equinor/appsec.git (fetch)
+origin	git@github.com:equinor/appsec.git (push)
+```
+
+- You can add and change remotes for a cloned repo, from HTTPS to SSH using the command `gir remote set-url <remote name> <new uri>`
+
+### Configure the SSH key for usage with Equinor's SSO protected resources
+
+The Equinor organization on github.com is protected behind SSO login. In order for your SSH key to be used with resources in the Github Equinor or Equinor-Playground organizations you need to authorize the key for these permissions on your behalf. [Github documentation](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on) gives you all the details.
+
+- To authorize your key head over to your [SSH Key Settings](https://github.com/settings/keys) on your profile on Github, select the key in question, select "Configure SSO" and authorize against organisation(s).
+
+### Rotating SSH keys
+
+!!! Tip "Rotate your SSH keys"
+
+    Your SSH keys, and passphrases, should be rotated at least on a yearly basis. Put an re-occurring appointment in your calender for this. This process could be automated, but doing it once in a while in manual mode may help you not to forget how things work.
+
+## Github.com
+
+### Basic config for your account
+
+You will find your Github settings at [https://github.com/settings/profile](https://github.com/settings/profile).
+
+We recommend the following settings:
+
+#### [Public profile](https://github.com/settings/profile)
+
+-   Use your full name
+-   Select an recognizable avatar/picture for profile picture
+
+
+#### [Emails](https://github.com/settings/emails)
+
+- Have a primary and a secondary email address registered
+- Select "Keep my email addresses private"
+- Select "Block command line pushed that expose my email"
+
+#### [Password and authentication](https://github.com/settings/security)
+
+- Enable Two-Factor authentication
+  - This is **not** the Two-Factor for your Equinor account, this is MFA for your account at Github.com
+- Enable multiple Two-Factor methods
+  - Authenticator App
+  - SMS/Text
+- Preferred 2FA method should be Authenticator app
+- (Experiment with PassKeys or Security Keys)
+- Extract "Recovery codes" and store in your password manager
+
+#### [Codespaces](https://github.com/settings/codespaces)
+
+- Enable GPG verification
+- Validate the "Editor preference"
+  - "Visual Studio Code for the Web" is a good option for many
+- Validate "Default retention period"
+  - 14 days may be a good period (Codespaces incurs storage charges)
+- Region
+  - Set manually to "Europe West"
+
+#### [Code security an analysis](https://github.com/settings/security_analysis)
+
+- "Push protection for yourself" should be enabled
+  - Block push with supported secrets against public repos
+
+#### [Applications](https://github.com/settings/installations)
+
+- On a regular basis (at least once a year) - review apps that you have authorised to act on your behalf
+- Github Apps
+  - Limit access to specific repos
+  - Uninstall apps that not are in use
+- Authorized OAuth Apps
+  - Review permissions
+  - Review organization access
+  - Revoke access if not in use
+  
+#### [Security log](https://github.com/settings/security-log)
+
+- Familiarize with the content of the security log
+
+#### [Developer settings](https://github.com/settings/developers)
+
+- Review Personal access tokens (PAT)
+  - Review scope
+  - Review organizational access
+  - Review repository access (fine grained)
+  - Review permissions (fine grained)
+  - Rotate token (maximum token life time should be 6 months)
+  - Delete if not in use
+
+Fine-grained tokens are in beta (March 2024). Don't use beta features for anything production.

--- a/docs/guidelines/git-github.md
+++ b/docs/guidelines/git-github.md
@@ -1,43 +1,51 @@
 # Git and Github
 
-This guideline contains some basic information on configuration of git and user profiles on github.com. Our perspective would be security and privacy. The guideline is by no means exhaustive, it's more an introduction to basic config and the correlation between git and github.com
+This guideline contains some basic information on configuration of Git and user profiles on github.com. Our perspective would be security and privacy. The guideline is by no means exhaustive, it's more an introduction to basic config and the correlation between Git and github.com
 
 !!! tip "Git vs Github.com"
-    Git is a distributed version control system for tracking changes in source code, while GitHub is a platform that hosts Git repositories online, facilitating collaboration and project management. GitHub builds upon Git, offering a centralized place for developers to share and work on code together.
 
-[The Equinor Developer Portal](https://developer.equinor.com/) contain our [Source Code Management System Policy](https://developer.equinor.com/governance/scm-policy/). Please make sure you are familiar with the content of this policy.
+    Git is a distributed version control system for tracking changes in source code, while GitHub is a platform that hosts Git repositories online. GitHub builds upon Git, offering a centralized place for developers to share and work on code together.
+
+
+!!! Info "The SCM Policy"
+
+    [The Equinor Developer Portal](https://developer.equinor.com/) contain our [Source Code Management System Policy](https://developer.equinor.com/governance/scm-policy/). Please make sure you are familiar with the content.
 
 ## TLDR;
 
-- Configure your local git with proper name and email. Use your full name with the profile. Use privacy options for hiding your github.com primary email.
-- For authentication and communication with github.com, use git with SSH and password protected private keys.
+- Configure your local Git with proper name and email. Use your full name with the profile. Use privacy options for hiding your github.com primary email.
+- For authentication and communication with github.com, use Git with SSH and passphrase protected private keys.
 - Use separate SSH keys for different client devices.
-- Book a yearly re-occurring event with yourself to rotate SSH keys and passphrases.
+- Book a yearly re-occurring event with yourself to rotate SSH keys.
 
 ## Git
 
-For this guideline our reference is using git from the command line. There are many tools in use which utilises git and hide the internal mechanics of git configuration within the tool.
+For this guideline we use Git from the command line. Be aware, there are many tools that hide the internal mechanics of Git within the tool. For these tools most settings are defined within the tool itself.
 
-We assume that git and ssh is installed on your system. We do not cover the installation process besides mentioning the fact now that git and ssh like any other piece of software, should be kept up-to-date.
+We assume that `git` and `ssh` are installed on your system. We do not cover the installation process besides mentioning the fact that git and ssh like any other piece of software must be kept up-to-date.
 
-The official [git documentation](https://git-scm.com/doc) is a good source for authoriative answers and deep dives.
+The official [Git documentation](https://git-scm.com/doc) is a good source for authoritative answers and deep dives.
 
 
-### How git manages config
+### How Git manages config
 
 Git is dependent on proper configuration to work. Configuration can be read from the command line (using the `-c` option), environment variables or files. The [official guide]([authoriative](https://git-scm.com/docs/git-config#_configuration)) provides the details. 
 
-We usually store git config in files. Git will read config from multiple files depending on their availability. The files are read in the order shown below, the `last value read` will take precedence over values read earlier.
+We usually store Git config in files. Git will read config from multiple locations depending on their availability. The files are read in the order shown below, the `last value read` will take precedence over values read earlier.
 
 1. System config (usually `/etc/gitconfig`)
 2. Config file in home directory (usually `$HOME/.gitconfig`)
 3. Repository config files (`$GITDIR/config`)
   
-The config files can be updated manually or by using git
+The config files can be updated manually with a text editor or by using Git
+
+Git configuration from the command line follow the following structure:
 
 ```shell
-git config <section>.<key> <value>
+git config options section.key value
 ```
+
+For the examples below no "scope" is provided so Git will expect that you are in a Git directory and then work with a repo config file. A error message will be given if this is not the case. Use the parameter `--system`, `--global` or `--local` to specify scope.
 
 Example; setting the user name:
 
@@ -58,20 +66,15 @@ Removing config looks like this:
 git config --unset user.name
 ```
 
-For the examples above no "scope" is provided so git will work with repo config file. Use the parameter `--system`, `--global` or `--local` to specify scope.
-
 Setting your user name for a global scope would look like this:
 
 ```shell
 git config --global user.name "Peter Pan"
 ```
 
-
 ### Recommended generic basic config
 
-!!! tip "Recommended generic config"
-
-    This section contains the recommended basic generic config for git.
+This section contains the recommended basic generic configuration for Git.
 
 
 ```shell
@@ -84,12 +87,12 @@ git config --global user.email "value"
 
 !!! tip "Additional email privacy"
 
-    We also recommend that you set the "Keep my email address private" and even "Block command line pushes that expose my email" in [email section](https://github.com/settings/emails) of your profile on github.com
+    We also recommend that you check the "Keep my email address private" and even "Block command line pushes that expose my email" in [email section](https://github.com/settings/emails) of your profile on github.com
 
 
 ### Using SSH with git
 
-Git uses HTTP or SSH to communicate with github.com. Both alternatives are viable and provide a good level of security. HTTP(S) assumes the usage of PAT (Personal Access Token) tokens rather than account passwords. A short threat model of the options could like this:
+Git uses HTTP or SSH to communicate with github.com. Both alternatives are viable and provide a good level of security. HTTP(S) assumes the usage of PAT (Personal Access Token) tokens rather than account passwords. A short threat model of the options contains the following sections:
 
 
 | Threat                | SSH (with password-protected keys)                       | HTTPS (with PATs)                                              |
@@ -102,63 +105,56 @@ Git uses HTTP or SSH to communicate with github.com. Both alternatives are viabl
 | **Availability**      | Direct; less prone to web attacks, but firewalls might block SSH. | High through standard web ports; PATs can be revoked or expire, requiring renewal for continued access. |
 | **Key/Token Expiry**  | SSH keys do not expire by default; requires manual rotation for security. | PATs can be configured to expire, forcing regular renewal and review of access permissions. |
 | **Theft of Credentials** | Risk mitigated by passphrase encryption of the private key. Physical access or malware required to steal. | Risk of PAT exposure, especially if stored insecurely or transmitted over insecure channels. |
-| **Least privilege** | SSH keys can inherit all permissions of a user. No granularity | PAT tokens can be configured for fine grained permissions and then provide access to all or only specific repos. This could strengthen security. Token management will add extra complexity. |
+| **Least privilege** | SSH keys inherit all permissions of a user. No granularity | PAT tokens can be configured for fine grained permissions and then provide access to all or only specific repos. This could strengthen security. Token management will add extra complexity. |
 
 
-!!! tip "Use SSH with git"
+!!! tip "Use SSH with Git"
 
-    We recommend using SSH with git authenticates and communicates with github.com. Private keys should be password protected (or stored in a strong key service/device, like Keychain on MacOS or Yubikey's)
+    We recommend using SSH when Git authenticates and communicates with github.com. Private keys should be passphrase protected
 
+### Configuring Git to use SSH
 
-### Configuring git to use SSH
+The [Connecting to GitHub with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) in the official Github documentation is a good source for detailed information.
 
-The [Connecting to GitHub with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) in the official Github doc is a good source for information.
-
-These would be the usual steps:
+The following sections of the guideline contains the usual steps to get started with SSH.
 
 #### [Generate a new SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)
   - Type of key should be `ed25519`
   - Specify a filename (`-f`). We assume you can have multiple keys and suggest a naming convention like "service"-"identity"-"index". The index could be creation date and then used for automating key rotation.
-  - Add a comment (`-C`) to help identify the key's purpose. This will be added to the public key as generic text and have no functional impact. It will not be exposed on github.com. However, the purpose of a public key is to "share it", so use with caution (PII).
+  - Add a comment (`-C`) to help identify the key's purpose. This will be added to the public key as generic text but will not have any functional impact. It will not be exposed on github.com. However, the purpose of a public key is to "share it", so use with caution (PII).
 
-Example; Creating a ssh key for the github handle `larskaare`
+Example; Creating a SSH key for the Github user `larskaare`
 
 ```shell
-ssh-keygen -t ed25519 -f ~/.ssh/github_larskaare_1 -C "Github ssh for machine 1"
+ssh-keygen -t ed25519 -f ~/.ssh/github_larskaare_1 -C "Github SSH auth key for machine 1"
 ```
 
 Two files are created, one named `github_larskaare_1` and one named `github_larskaare_1.pub`. The file with the `.pub` extension contains the public part of the key.
 
 !!! Tip "Re-using keys?"
 
-    We advice on creating separate ssh keys for separate machine and devices and not to re-use one key on them all.
+    We advice on creating separate SSH keys for separate machines and devices and not to re-use the same key on them all.
 
 !!! Tip "Passphrases"
 
     Store passphrases in a password manager.
 
-!!! Tip "Use a password manager to generate and serve SSK keys"
-
-    Using a decent password manager to generate, serve and protect the SSH keys could be a very good option. The private key will not be stored on disk and biometrics could be used to access keys.
-
 #### Configure SSH and adding the key to the key-agent
 
 Adding the generated SSH key to the `ssh-agent` gives you a secure repository for your private keys's passphrases. Adding keys and passphrases to the key agent eliminates the need to repeatedly enter the passphrase.
 
-Follow the [official documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent) of adding the SSH key to the ssh-agent. Be aware of the operating system selector at the top of the page - it will give you instructions for **Mac**, **Windows** and **Linux**.
-
+Follow the [official documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent) of and add the SSH key to the ssh-agent. Be aware of the operating system selector at the top of the page - it will give you instructions for **Mac**, **Windows** and **Linux**.
 
 #### Adding SSH config
 
-SSH uses a config files for it's configuration (these are not the same files that git use). The user-specific file is usually stored in `~/.ssh/config` and should updated prior to using the SSH key and the ssh-key agent. Depending on you version of SSH, documentation is often available using the command `man ssh_config`. The [OpenSSH Manual Pages](https://www.openssh.com/manual.html) could also be a good resource.
+SSH uses a config file for it's configuration (this file is not used by Git). The user-specific file is usually stored in `~/.ssh/config` and should be updated prior to using the SSH key and the ssh-key agent. Consult the documentation of your SSH client for details. (Many use OpenSSH which have good manual pages - [OpenSSH Manual Pages](https://www.openssh.com/manual.html))
 
-A typical set-up for MacOS for the key we generated in the example would look like this:
+A SSH config file with minimum set-up usually looks like this:
 
 ```
 Host github.com
     AddKeysToAgent yes
     IdentitiesOnly=yes
-    UseKeychain yes
     IdentityFile ~/.ssh/github_larskaare_1
 ```
 
@@ -182,14 +178,17 @@ ssh-add --apple-use-keychain ~/.ssh/github_larskaare_1
 
 We now have a SSH key that we can use when communicating with github.com. To be able to use this key with Github we need to upload the public part of the key to github.com
 
-- List public key
+- Print the public key
+
 ```shell
-   cat ~/.ssh/github_larskaare_1.pub
+cat ~/.ssh/github_larskaare_1.pub
 ```
 
 - Copy the public key and add it as a new SSH Authentication key to your Github profile at [https://github.com/settings/keys](https://github.com/settings/keys)
 
 - Verify that Github accepts the key, test the connection
+
+(When testing the connection to github.com, ssh will ask if the fingerprint of the SSH key presented by github.com is ok and if you would like to continue. If you are connecting to github.com answer "yes". Understanding this trust chain is not for this guide - but if you want to validate the fingerprint that's suggested you can correlate it to the [official ssh key fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints). The known hosts file that is mentioned is the `~/.ssh/known_hosts` file)
 
 ```shell
 ssh -T git@github.com
@@ -201,11 +200,11 @@ The command should a message similar to this to indicate success:
 Hi larskaare! You've successfully authenticated, but GitHub does not provide shell access.
 ```
 
-### Using git with SSH with github
+### Using Git and SSH with github
 
-A this stage we have SSH all configured on both ends, how do we tell git to use SSH? You typically would do this when cloning a repo or configuring the `remote`
+A this stage we have SSH all configured on both ends. However, how do we tell git to use SSH? You typically would do this when cloning a repo or configuring the `remote`
 
-- A git clone command like this `git clone git@github.com:equinor/appsec.git` tells git to use SSH. The same command for using HTTPS would be git `git clone https://github.com/equinor/appsec.git`. The giveaway for SSH would be the username part `git@github.com` of the url.
+- A git clone command like this `git clone git@github.com:equinor/appsec.git` tells git to use SSH. The same command for using HTTPS would be git `git clone https://github.com/equinor/appsec.git`. The giveaway for HTTPS would be the url which starts with https 😅 That is not included when we use SSH - we rather have the `git@github.com` part of the url.
 - You can examine the remote of a repo to identify if it uses SSH or HTTPS
 
 ```shell
@@ -219,11 +218,11 @@ origin	git@github.com:equinor/appsec.git (fetch)
 origin	git@github.com:equinor/appsec.git (push)
 ```
 
-- You can add and change remotes for a cloned repo, from HTTPS to SSH using the command `gir remote set-url <remote name> <new uri>`
+- You can add and change remotes for a cloned repo, from HTTPS to SSH using the command `git remote set-url <remote name> <new uri>`
 
 ### Configure the SSH key for usage with Equinor's SSO protected resources
 
-The Equinor organization on github.com is protected behind SSO login. In order for your SSH key to be used with resources in the Github Equinor or Equinor-Playground organizations you need to authorize the key for these permissions on your behalf. [Github documentation](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on) gives you all the details.
+The Equinor organization on github.com is protected behind SSO login. In order for your SSH key to be used with resources in the Github "Equinor" or "Equinor-Playground" organizations you need to authorize the key for these permissions on your behalf. [Github documentation](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on) gives you all the details.
 
 - To authorize your key head over to your [SSH Key Settings](https://github.com/settings/keys) on your profile on Github, select the key in question, select "Configure SSO" and authorize against organisation(s).
 
@@ -256,7 +255,7 @@ We recommend the following settings:
 #### [Password and authentication](https://github.com/settings/security)
 
 - Enable Two-Factor authentication
-  - This is **not** the Two-Factor for your Equinor account, this is MFA for your account at Github.com
+  - This is **not** the Two-Factor for your Equinor account, this is for your account at github.com
 - Enable multiple Two-Factor methods
   - Authenticator App
   - SMS/Text
@@ -301,7 +300,7 @@ We recommend the following settings:
   - Review organizational access
   - Review repository access (fine grained)
   - Review permissions (fine grained)
-  - Rotate token (maximum token life time should be 6 months)
+  - Rotate token (maximum token life time should be 12 months)
   - Delete if not in use
 
 Fine-grained tokens are in beta (March 2024). Don't use beta features for anything production.

--- a/docs/guidelines/git-signed-commits.md
+++ b/docs/guidelines/git-signed-commits.md
@@ -1,0 +1,1 @@
+# Signed git commits

--- a/docs/guidelines/git-signed-commits.md
+++ b/docs/guidelines/git-signed-commits.md
@@ -1,1 +1,172 @@
 # Signed git commits
+
+The code from our software configuration management system (SCM) is the starting point for a lot of secure coding practices. Signed Git commits are an essential security practice which provides a layer of verification that helps mitigate several threats. Some of these threats are:
+
+- **Impersonation**: Signed commits use keys to sign the work. By doing so, they certify that the commit was made by the claimed individual. This helps prevent an attacker from impersonating a developer and submitting malicious code.
+
+- **Code tampering**: Signing commits ensures the integrity of the code from the time it was committed. If the code is altered in any way after it was signed, the signature will no longer be valid. This helps protect against unauthorized code modifications, which could introduce vulnerabilities or malicious code.
+
+- **Replay attacks**: Signed commits can help mitigate replay attacks where an attacker attempts to re-submit a legitimate commit to a different context, potentially causing unintended consequences. The signature verifies not just the content of the commit but also its context within the repository history.
+
+- **Long-term repository integrity**: By using signed commits, organizations can ensure the long-term integrity of their codebase. This is crucial for auditing and tracking the provenance of code changes, making it easier to trace back and verify the authenticity of commits over time.
+
+- **Increased trust and compliance**: For projects that require strict compliance and governance standards, signed commits provide a mechanism to enforce these policies. They increase trust among contributors and users by ensuring that all changes are authenticated and authorized by the rightful committers.
+
+## TLDR;
+
+- Sign all your Git commits
+- Use SSH, with a passphrase protected private key, to sign your Git commits
+- Use separate SSH keys for signing and authentication
+- Use branch protection and required signed Git commits
+
+## Signing methods
+
+The official [github documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signature verification shows that commits can be signed using GPG, SSH or S/MIME. The 3 different methods have their pros and cons.
+
+| Feature/Aspect             | SSH Signing                                                | GPG Signing                                                    | S/MIME Signing                                               |
+|----------------------------|------------------------------------------------------------|----------------------------------------------------------------|--------------------------------------------------------------|
+| **Basic Mechanism**        | Uses SSH keys for both authentication and signing. | Utilizes a public-private key pair specifically for signing.   | Uses certificates issued by a Certificate Authority (CA).    |
+| **Identity Verification**  | SSH public keys are used to verify the signature.           | Verification is based on a web of trust or direct key sharing. | Relies on certificates verified and issued by trusted CAs.   |
+| **Infrastructure**         | Requires SSH key setup; already needed for repository access. | Requires GPG software and management of key pairs.             | Requires obtaining and managing a certificate from a CA. Potential complex PKI     |
+| **Ease of Setup**          | Simple for users already using SSH keys for Git operations.  | Can be complex due to key generation, management, and sharing. | Varies; obtaining a certificate can be straightforward or complex depending on the provider. |
+| **Cross-platform Support** | Broad support across various platforms and Git tools.        | Well-supported, with widespread integration in Git tools.      | Support varies; some tools may not support S/MIME directly.   |
+| **Pros**                   | - Simplifies workflow by using the same keys for authentication and signing. <br> - Integrated into SSH, which is commonly used for secure Git operations. | - Decentralized and flexible, with a variety of algorithms and key sizes. <br> - Well-established in the open-source community. | - Trust model is straightforward, based on established CAs. <br> - May align with existing certificate-based security practices (e.g., email). |
+| **Cons**                   | - Primarily verifies the commit was pushed by an authenticated user, not necessarily the commit's author. <br> - SSH key management is crucial; compromised keys pose a risk. | - Key management and the web of trust model can be complex. <br> - Requires active key maintenance (revocation, expiration). | - Dependent on third-party CAs for issuance and trust. <br> - Certificates have expiration dates and may incur costs. |
+
+!!! Note Signing method
+
+    We recommend using self-signed SSH keys for signing your git commits (In the future we may switch to a certificate based approach)
+
+## Configure your local development environment
+
+For this guideline our reference is using Git from the command line. 
+
+We assume that Git and SSH is installed on your system. 
+
+We assume that you are using SSH to authenticate Git with github.com. Consult our [guideline](git-github.md) for more information on this topic.
+
+The Github documentation on [SSH commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification) is a good source for detailed information.
+
+### Adding a SSH key for signing
+
+!!! Note Use multiple SSH keys
+
+    We recommend using different SSH keys for authentication and signing. This may add some extra complexity and it may provide a more robust set-up with looser coupling of key components of the SDLC.
+
+To create a new SSH key for signing you can use the following command (alter the date manually):
+
+```shell
+ssh-keygen -t ed25519 -f ~/.ssh/git_ssh_signing_key_1 -C "Created on <date>, for larskaare on github.com"
+```
+
+This will create a SSH signing key and add a comment on date and purpose. Add a passphrase to the key. Success full key generation will output the key fingerprint and a randomart image (randomart is supposed to be a visualisation making it easier to validate keys - and identify changes)
+
+Add the new key to the ssh-agent
+
+```shell
+ssh-add ~/.ssh/git_ssh_signing_key_1
+```
+
+### [Configure Git](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key) to use the SSH key
+
+We will configure the git global settings to use the new SSH key for signing commits locally. Examples assume you created the key as defined above.
+
+```shell
+git config --global gpg.format ssh
+git config --global user.signingkey $HOME/.ssh/git_ssh_signing_key_1.pub
+git config --global commit.gpgsign true
+```
+
+These lines will tell git to use SSH for signing commit, tell git where to find the key that should be used and then tell git to always sign commits. If you do not add this last line you will specifically have to add the `-S` parameter for each commit you can to sign.
+
+### Examining the git log
+
+To verify that commits are signed locally you can use the following command:
+
+```shell
+git log --show-signature
+```
+
+When you run this command on a newly configured system you may get an error message like `error: gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification` In order for git to verify signatures locally you need to add the public keys that are used to sign to a file that Git will use.
+
+We will create the allowed_signers file. It typically has the format like "signer email" "key-type" "key-body". The key in question is the public key of the SSH key we use to sign our commits.
+
+```shell
+git config --global gpg.ssh.allowedSignersFile $HOME/.ssh/allowed_signers
+echo $(git config --get user.email) \
+     $(cat ~/.ssh/git_ssh_signing_key_1.pub) \
+     | awk '{print $1,$2,$3}' >> ~/.ssh/allowed_signers
+```
+
+- The first line tells Git which file we are going to use for allowed_signers
+- The second line emits the information on our key and adds it to the allowed_signers file. The file is created if it does not exist
+
+When this is done you can view the git log and verify the signature.
+
+```shell
+git log --show-signature
+```
+
+The `git verify-commit` options is also available. To verify the commit on HEAD you can use the following command:
+
+```shell
+git verify-commit HEAD
+```
+
+Use the verbose parameter to get more information:
+
+```shell
+git verify-commit -v HEAD
+```
+
+!!! tip Sign git tags
+
+    We have shown how to sign git commits. You can also sign git tags!
+
+
+## Configure Github
+
+At this stage in the guideline we are able to sign and verify the signature of locally committed changes. If you push your changes to github.com they will get the `Unverified` status. This indicate that Github has found a signature in the commit but it is not able to verify it. You can find more detailed information on the Github docs on [About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+
+This makes sense. Github can not verify our signature, it does not have our public key. Telling Github about the public key we used to sign our commit is the next step.
+
+### Adding public keys
+
+We will add the public part of our SSH key to github.com.
+
+- Print the public part of the key
+
+```shell
+cat ~/.ssh/git_ssh_signing_key_1.pub
+```
+
+- Copy the public key and add it as a new [Signing key](https://github.com/settings/ssh/new) to your profile on github.com. Provide a proper title. Key type must be "Signing Key".
+
+If you now go back and look at the commits on github.com, those that were signed with the new key should have status `Verified`
+
+If you select the `Verified` badge you will get information on the signer and the fingerprint of the public key that was used. You can find the finger print by [looking at the key](https://github.com/settings/keys) on your Github profile or by running ssh-keygen with the option to generate fingerprint locally:
+
+```shell
+ssh-keygen -lf ~/.ssh/git_ssh_signing_key_1
+```
+
+!!! Tip Vigilant Mode 
+
+    Explore Github's [Vigilant Mode](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits#about-vigilant-mode) It should increase the trust level of signed commits yet another level.
+
+### Branch protection
+
+We recommend that you protect important branches with branch protection rules on. This is a feature of Github that requires a Github Team or Github enterprise account.
+
+The official documentation can be found in [Managing protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches)
+
+We recommend the following **minimum** protection for important branches:
+
+- Protect matching branches
+    - Check "Require a pull request before merging" 
+    - Check "**Require signed commits**"
+    - Check "Do not allow bypassing the above settings"
+- Rules applied to everyone including administrators
+    - UnCheck "Allow force pushes"
+    - UnCheck "Allow deletions"
+  

--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -12,3 +12,5 @@ This section contains guidelines relevant anyone writing code in Equinor.
 - [Postman](postman.md)
 - [Authentication and Authorization](authn-authz.md)
 - [Github Actions and Self-Hosted Runners](gh-actions-runners.md)
+- [Git and Github](git-github.md)
+- [Signed git commits](git-signed-commits.md)


### PR DESCRIPTION
This is the initial take and suggestion for two guidelines and recommendations:

- Using SSH for Git authentication towards github.com
- Using self singed SSH keys for signing commits

The format is not a strict recommendation or guideline - it's a more explaining guideline with recommendations - hopefully inviting the user to experient and test to get a better understanding of the mechanics.

Let the discussion begin 🤓