### PR TITLE
deps(workflow): bump actions in gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: 
           fetch-depth: 0
       - uses: actions/setup-python@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
         with: 
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt


### PR DESCRIPTION
Bumping third party actions, which should mitigate the warnings about using [deprecated ](https://github.com/equinor/appsec/actions/runs/8568131718)node version in the workflows:
* bump actions/checkout from v3 to v4
* bump actions/setup-python from v4 to v5

⚠️ Assert that the workflow is working after merging, as the workflow runs on push to main.

ℹ️ Seems like we do not need to modify our whitelist of actions, it is permissive enough to allow these changes.