### PR TITLE
chore: pin GitHub actions by full length SHA

### DIFF
--- a/.github/workflows/azure-static-webapp.yml
+++ b/.github/workflows/azure-static-webapp.yml
@@ -1,4 +1,3 @@
-
 name: Azure Static Web Apps CI/CD
 
 on:
@@ -10,16 +9,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with: 
             fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt
       - run: mkdocs build
 
-      - uses: Azure/static-web-apps-deploy@v1
+      - uses: azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GRAY_PEBBLE_09FADDD03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,16 +1,18 @@
 name: gh-pages
+
 on:
   push:
     branches:
       - main
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with: 
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,12 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+
+version: 2
+updates:
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
- follow our own [recommendation](https://equinor.github.io/appsec/guidelines/gh-actions-runners/#github-actions-in-general) and pin 3rd party action by full length SHA
- add dependabot (GitHub owned) to keep actions up to date automatically (PRs will be created once a week)