### PR TITLE
deps(actions): setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
Setting up Dependabot for Actions, having them bumped on a weekly basis.

This was suggested by @dbelyaev in 
* #134 

