### PR TITLE
docs(guidelines): update title

### DIFF
--- a/docs/guidelines/authn-authz.md
+++ b/docs/guidelines/authn-authz.md
@@ -1,4 +1,4 @@
-# Authentication and Authorization guidelines
+# Authentication and Authorization
 
 Authentication and Authorization are complex topics. Things are often very context specific. Answers are often not straight forward, we often have more than one option. In the sections below we will give advice on protocols, tools and principle we find helpful.
 

--- a/docs/guidelines/gh-actions-runners.md
+++ b/docs/guidelines/gh-actions-runners.md
@@ -1,4 +1,4 @@
-# GitHub Actions and Self-Hosted Runners Guideline
+# GitHub Actions and Self-Hosted Runners
 
 The scope of this guideline is to provide generic security advice for GitHub Actions and specific security advice for using self-hosted runners.
 

--- a/docs/guidelines/git-signed-commits.md
+++ b/docs/guidelines/git-signed-commits.md
@@ -1,4 +1,4 @@
-# Signed git commits
+# Signed commits
 
 The code from our software configuration management system (SCM) is the starting point for a lot of secure coding practices. Signed Git commits are an essential security practice which provides a layer of verification that helps mitigate several threats. Some of these threats are:
 

--- a/docs/guidelines/index.md
+++ b/docs/guidelines/index.md
@@ -1,16 +1,15 @@
 ---
 layout: page
-title: Appsec guidelines
+title: AppSec guidelines
 ---
 
-## Equinor Appsec guidelines
+## Equinor AppSec guidelines
 
 This section contains guidelines relevant anyone writing code in Equinor.
 
-- [Snyk](../snyk/index.md)
-- [Scanning for Secrets in code](secret-scanning.md)
-- [Postman](postman.md)
 - [Authentication and Authorization](authn-authz.md)
 - [Github Actions and Self-Hosted Runners](gh-actions-runners.md)
 - [Git and Github](git-github.md)
-- [Signed git commits](git-signed-commits.md)
+- [Signed commits](git-signed-commits.md)
+- [Scanning for Secrets in code](secret-scanning.md)
+- [Snyk](../snyk/index.md)


### PR DESCRIPTION
Removing the word "guideline" from the title, as it is implicitly given from the location this documentation resides in.

This solves #139.