### PR TITLE
docs: remove guideline PR activity

### DIFF
--- a/docs/security-champion/4-learning-platform.md
+++ b/docs/security-champion/4-learning-platform.md
@@ -53,7 +53,6 @@ Please help contribute with useful activities that make sense in Equinor context
 - Set up Secret scanning for your project [using our guidelines](https://appsec.equinor.com/guidelines/secret-scanning/)
 - Have a Security Champion from another team join/review your threat model
 - Join/review another team's threat model
-- Publish or suggest changes to guidelines on [appsec.equinor.com](https://appsec.equinor.com/guidelines/)
 - Attend a Security Journey tournament
 - Gain three ```white``` belts
 - Gain two ```yellow``` belts


### PR DESCRIPTION
Remove the guideline PR activity as we should have a good internal process for handling this before adding it again.