### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-webapp.yml
+++ b/.github/workflows/azure-static-webapp.yml
@@ -1,5 +1,7 @@
 
 name: Azure Static Web Apps CI/CD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/appsec/security/code-scanning/1](https://github.com/equinor/appsec/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for most steps, and the `pull-requests: write` permission is not needed. The `repo_token` used in the `Azure/static-web-apps-deploy` action already uses a secret token, so no additional permissions are required for that step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
