### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,6 @@
 name: gh-pages
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/appsec/security/code-scanning/2](https://github.com/equinor/appsec/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow deploys documentation using `mkdocs gh-deploy`, it requires write access to the `contents` scope. We will set the `permissions` block at the root level of the workflow to apply to all jobs, ensuring that the `GITHUB_TOKEN` has only the necessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
