### PR TITLE
Fix Varia TechDocs build

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,8 @@ metadata:
   description: appsec.equinor.com
   annotations:
     github.com/project-slug: "equinor/appsec"
-    backstage.io/techdocs-ref: dir:./docs      
+    backstage.io/techdocs-ref: dir:.
+    equinor.com/techdocs-builder: host
   links:
     - url: 'https://appsec.equinor.com/'
       title: 'Official Equinor AppSec Website'


### PR DESCRIPTION
* Add `equinor.com/techdocs-builder: host` to trigger building of the documentation in Varia.
* Change `backstage.io/techdocs-ref` to point to the folder for `mkdocs.yaml` (which is repo root)

Once this is merged and proves to work, the GitHub TechDocs workflow can be deleted.