### PR TITLE
Adjustment Backstage

### DIFF
--- a/.github/workflows/backstage-techdocs.yml
+++ b/.github/workflows/backstage-techdocs.yml
@@ -1,9 +1,9 @@
 name: Build TechDocs
 
 on:
-  push:
-    branches:
-      - main
+  #push:
+  #  branches:
+  #    - main
   workflow_dispatch:
     
 jobs:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   description: appsec.equinor.com
   annotations:
     github.com/project-slug: "equinor/appsec"
-    backstage.io/techdocs-ref: dir:./docs      
+    backstage.io/techdocs-ref: dir:.
   links:
     - url: 'https://appsec.equinor.com/'
       title: 'Official Equinor AppSec Website'


### PR DESCRIPTION
Build and upload of techdocs to backstage will use SP RBAC instead of storage account key.

In this PR:

- Temporary disable automatic build and push of techdocs until federated login is in place
- Adjust incorrect path