### PR TITLE
Change destination for techdocs

### DIFF
--- a/.github/workflows/backstage-techdocs.yml
+++ b/.github/workflows/backstage-techdocs.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      id-token: write
       contents: read
+
 
     env:
       STORAGE_ACCOUNT_NAME: ${{ vars.BACKSTAGE_PROD_STORAGE_ACCOUNT_NAME }}


### PR DESCRIPTION
See Issue: https://github.com/equinor/isc-appsec/issues/1823

Changing sink for generated techdocs to Varia.

Building techdocs ourselves to adjust to our use of mkdoc plugins not supported in Varia