### PR TITLE
fix(docs): stale reference removed

### DIFF
--- a/docs/toolbox/github-advanced-security/setup.md
+++ b/docs/toolbox/github-advanced-security/setup.md
@@ -2,7 +2,6 @@
 # GitHub Advanced Security Enablement and Setup
 
 !!! important
-    - Internal and Private Repositories must wait until **1st of October** before enabling GHAS.
     - You must be a repository Admin to proceed.
 
 <br/>


### PR DESCRIPTION
See: #261 

- Removes reference used before GHAS was fully implemented 